### PR TITLE
Allow unauthenticated calls to /health

### DIFF
--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -16,8 +16,8 @@ pub async fn require_bearer_auth(
 ) -> Result<Response, StatusCode> {
     // Get the current request path
     let path = req.uri().path();
-    // Allow access to auth metadata
-    if path.starts_with("/.well-known/") {
+    // Allow access to auth metadata and health check endpoint
+    if path.starts_with("/.well-known/") || path == "/health" {
         return Ok(next.run(req).await);
     }
     // Check for an Authorization header


### PR DESCRIPTION
#  Description

White listes the health endpoint so it can be called without auth.

## Testing

Tested locally.