### PR TITLE
fix: install default crypto provider when starting server

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,8 @@ mod utils;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    if let Err(e) = rustls::crypto::ring::default_provider().install_default() {
-        tracing::error!("Failed to install default crypto provider: {:?}", e);
+    if let Err(_) = rustls::crypto::ring::default_provider().install_default() {
+        tracing::error!("Failed to install default crypto provider");
     }
 
     // Parse command line arguments

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,10 @@ mod utils;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    if let Err(e) = rustls::crypto::ring::default_provider().install_default() {
+        println!("Failed to install default crypto provider: {:?}", e);
+    }
+
     // Parse command line arguments
     let cli = cli::Cli::parse();
     // Run the specified command

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,10 @@ mod utils;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    if let Err(_) = rustls::crypto::ring::default_provider().install_default() {
+    if rustls::crypto::ring::default_provider()
+        .install_default()
+        .is_err()
+    {
         tracing::error!("Failed to install default crypto provider");
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ mod utils;
 #[tokio::main]
 async fn main() -> Result<()> {
     if let Err(e) = rustls::crypto::ring::default_provider().install_default() {
-        println!("Failed to install default crypto provider: {:?}", e);
+        tracing::error!("Failed to install default crypto provider: {:?}", e);
     }
 
     // Parse command line arguments


### PR DESCRIPTION
Should solve the following issue raised by a community member:

```
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
Call CryptoProvider::install_default() before this point to select a provider manually, or make sure exactly one of the 'aws-lc-rs' and 'ring' features is enabled.
See the documentation of the CryptoProvider type for more information.
            
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```