### PR TITLE
feat: Auto-reconnect on token expiry and connection loss

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -20,6 +20,8 @@ pub struct Response {
     pub error: Option<String>,
     /// The result of the query as a formatted string
     pub result: Option<surrealdb::Response>,
+    /// Whether this error requires reconnection (e.g., token expired)
+    pub requires_reconnect: bool,
 }
 
 impl Response {
@@ -101,31 +103,52 @@ pub async fn execute_query(
                 error: None,
                 duration,
                 query_id,
+                requires_reconnect: false,
             }
         }
         Err(e) => {
             // Get the duration of the query
             let duration = start_time.elapsed();
+            let error_str = e.to_string();
+            // Check if this is a token expiration error that requires reconnection
+            let requires_reconnect = is_reconnectable_error(&error_str);
             // Output debugging information
             error!(
                 connection_id = %connection_id,
                 query_id,
                 query = %query_string,
                 duration_ms = duration.as_millis(),
-                error = %e,
+                error = %error_str,
+                requires_reconnect,
                 "Query execution failed"
             );
             // Update query metrics
             counter!("surrealmcp.total_query_errors").increment(1);
             histogram!("surrealmcp.query_duration_ms").record(duration.as_millis() as f64);
+            if requires_reconnect {
+                counter!("surrealmcp.token_expiry_errors").increment(1);
+            }
             // Return the response
             Response {
                 query: query_string,
                 result: None,
-                error: Some(e.to_string()),
+                error: Some(error_str),
                 duration,
                 query_id,
+                requires_reconnect,
             }
         }
     }
+}
+
+/// Check if an error message indicates a reconnectable condition
+/// (token expired, connection lost, etc.)
+fn is_reconnectable_error(error: &str) -> bool {
+    let error_lower = error.to_lowercase();
+    error_lower.contains("token has expired")
+        || error_lower.contains("token expired")
+        || error_lower.contains("authentication failed")
+        || error_lower.contains("connection reset")
+        || error_lower.contains("connection refused")
+        || error_lower.contains("broken pipe")
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1897,11 +1897,54 @@ This is useful when you want to:
                 let res = engine::execute_query(
                     db,
                     query_id,
-                    query_string,
-                    parameters,
+                    query_string.clone(),
+                    parameters.clone(),
                     &self.connection_id,
                 )
                 .await;
+
+                // Check if we need to reconnect (token expired, connection lost, etc.)
+                if res.requires_reconnect {
+                    info!(
+                        connection_id = %self.connection_id,
+                        query_id,
+                        "Token expired or connection lost, attempting automatic reconnection"
+                    );
+                    // Drop the guard to allow reconnection
+                    drop(db_guard);
+
+                    // Attempt to reconnect
+                    if let Err(e) = self.initialize_connection().await {
+                        error!(
+                            connection_id = %self.connection_id,
+                            error = %e,
+                            "Failed to reconnect after token expiration"
+                        );
+                        counter!("surrealmcp.reconnection_failures").increment(1);
+                        return Ok(res); // Return original error
+                    }
+
+                    counter!("surrealmcp.reconnection_successes").increment(1);
+                    info!(
+                        connection_id = %self.connection_id,
+                        "Successfully reconnected, retrying query"
+                    );
+
+                    // Retry the query with fresh connection
+                    let db_guard = self.db.lock().await;
+                    if let Some(db) = &*db_guard {
+                        let retry_id = QUERY_COUNTER.fetch_add(1, Ordering::SeqCst);
+                        return Ok(engine::execute_query(
+                            db,
+                            retry_id,
+                            query_string,
+                            parameters,
+                            &self.connection_id,
+                        )
+                        .await);
+                    }
+                }
+
                 // Return the response
                 Ok(res)
             }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1942,6 +1942,13 @@ This is useful when you want to:
                             &self.connection_id,
                         )
                         .await);
+                    } else {
+                        // Database connection failed after reconnect attempt
+                        error!(
+                            connection_id = %self.connection_id,
+                            "Database unavailable after successful reconnection"
+                        );
+                        return Ok(res); // Return original error
                     }
                 }
 


### PR DESCRIPTION
## Summary

When a query fails due to token expiration or connection issues, the client now automatically reconnects and retries the query transparently.

### Changes

- **engine/mod.rs**: Added `requires_reconnect` field to `Response` and `is_reconnectable_error()` detection function
- **tools/mod.rs**: Added automatic reconnection + retry logic when reconnectable errors occur

### Detected Error Types

- Token expired / token has expired
- Authentication failed
- Connection reset / connection refused
- Broken pipe

### Observability

New metrics added:
- `surrealmcp.token_expiry_errors` - counts token expirations
- `surrealmcp.reconnection_successes` - successful auto-reconnects  
- `surrealmcp.reconnection_failures` - failed reconnection attempts

### Benefits

- Resilient long-running sessions without manual intervention
- Transparent to the user - queries just work
- Non-breaking - backward compatible addition

## Test Plan

- [ ] Test with expired token scenario
- [ ] Test with connection drop scenario
- [ ] Verify metrics are emitted correctly
- [ ] Verify query retry succeeds after reconnection

---
🤖 Generated with [Claude Code](https://claude.ai/code)